### PR TITLE
Update Coffeescript URL and make settable through options

### DIFF
--- a/src/ClientBundler/HtmlHelper.cs
+++ b/src/ClientBundler/HtmlHelper.cs
@@ -41,7 +41,7 @@ namespace ClientBundler
                .Select(x => x.ScriptTag())
            )
          ) +
-         "<script src=\"http://coffeescript.org/extras/coffee-script.js\"></script>"
+         string.Format("<script src=\"{0}\"></script>", Options.CoffeeScriptUrl)
       );
     }
 

--- a/src/ClientBundler/HtmlHelper.cs
+++ b/src/ClientBundler/HtmlHelper.cs
@@ -77,7 +77,7 @@ namespace ClientBundler
          ) +
          Environment.NewLine
          +
-         "http://coffeescript.org/extras/coffee-script.js"
+         Options.CoffeeScriptUrl
       );
     }
 

--- a/src/ClientBundler/Options.cs
+++ b/src/ClientBundler/Options.cs
@@ -22,6 +22,11 @@
       get { return "true" == Setting("Assets.Precompiled"); }
     }
 
+    public static string CoffeeScriptUrl
+    {
+      get { return Setting("Assets.CoffeeScriptUrl") ?? "http://coffeescript.org/v1/extras/coffee-script.js"; }
+    }
+
     static string Setting(string key)
     {
       return System.Configuration.ConfigurationManager.AppSettings[key];


### PR DESCRIPTION
Old Coffeescript URL, `http://coffeescript.org/extras/coffee-script.js` has been changed into `http://coffeescript.org/v1/extras/coffee-script.js`